### PR TITLE
Add error message when there is no required parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/taichi/ci-yarn-upgrade",
   "dependencies": {
     "cli-table2": "^0.2.0",
+    "colors": "^1.1.2",
     "commander": "^2.9.0",
     "cross-spawn": "^5.0.1",
     "git-url-parse": "^6.0.7",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import moment from "moment";
 import { isString } from "lodash";
 import { Command } from "commander";
+import colors from "colors/safe";
 
 import pkg from "../package.json";
 import ur from "./upgrade-request";
@@ -20,9 +21,9 @@ cmd.version(pkg.version)
     .option("--with-shadows", "if you specify this option, shows shadow dependencies changes.", false)
     .parse(process.argv);
 
+/* eslint-disable no-console */
 if (cmd.username && cmd.useremail && cmd.token) {
     cmd.now = moment().format("YYYYMMDDhhmmss");
-    /* eslint-disable no-console */
     cmd.logger = cmd.verbose ? m => console.log(`> ${m}`) : () => { };
     Promise.all([ur(cmd)])
         .then(([msg]) => {
@@ -37,7 +38,8 @@ if (cmd.username && cmd.useremail && cmd.token) {
                 process.exit(1);
             }
         });
-    /* eslint-enable no-console */
 } else {
+    console.log(colors.red("Please set required parameters: username, useremail, token"));
     cmd.help();
 }
+/* eslint-enable no-console */


### PR DESCRIPTION
I did not know what was wrong when I ran `ci-yarn-upgrade --execute` without setting required parameters.(username, useremail, token)
So, I want to notify when there are no required parameters.

@taichi please review it 🙏 

### Before

![1 tmux 2017-01-04 17-36-27](https://cloud.githubusercontent.com/assets/1830471/21636047/5522a89e-d2a4-11e6-8300-8588c3baab12.png)

### After

![1 tmux 2017-01-04 17-46-43](https://cloud.githubusercontent.com/assets/1830471/21636346/c7106a80-d2a5-11e6-8bd7-9039531fd4d1.png)

