### PR TITLE
Fix error due to yarn outdated returns 1

### DIFF
--- a/src/yarnpkg.js
+++ b/src/yarnpkg.js
@@ -19,6 +19,10 @@ export default class {
             .then(out => {
                 this.LOG("END   yarnpkg outdated");
                 return out.stdout.trim();
+            })
+            .catch(out => {
+                this.LOG("END   yarnpkg outdated");
+                return out.stdout.trim();
             });
     }
 


### PR DESCRIPTION
ci-yarn-upgrade command doesn't work because `yarn outdated` return 1 exit code from following commit.  So I fix it.

[Exit process with code 1 when outdated dependencies are found by KishanBagaria · Pull Request #3484 · yarnpkg/yarn](https://github.com/yarnpkg/yarn/pull/3484/commits/eace79b8ee254d481725ef1485a3b8325ce1dd4f)
