### PR TITLE
Fix: no compare link

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -95,7 +95,7 @@ function reconcile(LOG, github, dep, c) {
     if (dep.repository) {
         if (dep.repository.url) {
             let u = giturl(dep.repository.url);
-            c.repo = u && u.toString("https");
+            c.repo = u && u.toString("https").replace(/\.git$/, "");
         }
         if (_.isString(dep.repository) && 2 === dep.split("/")) {
             c.repo = `https://github.com/${dep.repository}`;

--- a/src/github.js
+++ b/src/github.js
@@ -62,7 +62,7 @@ class CompareModel {
 
 function selectGetTagsPromise(LOG, github, c) {
     let handler = (prev, res) => {
-        let tags = prev.concat(res.map(t => t.ref.split("/")[2]));
+        let tags = prev.concat(res.data.map(t => t.ref.split("/")[2]));
         if (github.hasNextPage(res)) {
             return github.getNextPage(res).then(r => handler(tags, r));
         }


### PR DESCRIPTION
As you might notice, there is no compare link in recent PRs.
(e.g. https://github.com/taichi/ci-yarn-upgrade/pull/51)

There are 2 problems.

1. It fails to get tags properly. This is because `github.gitdata.getTags` now returns object `{ data: [...], meta: ... }`, not array. 
2. URL contains trailing `.git`

Here is fixed output.

## Updating Dependencies

| Name | Updating | Latest | dependencies | devDependencies |
|:---- |:--------:|:------:|:-:|:-:|
| [ava](https://ava.li) | [0.22.0](https://github.com/avajs/ava/tree/v0.22.0) | [0.25.0](https://github.com/avajs/ava/compare/v0.22.0...v0.25.0) |   | * |
| [chokidar](https://github.com/paulmillr/chokidar) | [1.7.0](https://github.com/paulmillr/chokidar/tree/1.7.0) | [2.0.2](https://github.com/paulmillr/chokidar/compare/1.7.0...2.0.2) |   | * |
| [commander](https://github.com/tj/commander.js#readme) | [2.12.2...2.14.1](https://github.com/tj/commander.js/compare/v2.12.2...v2.14.1) | [2.14.1](https://github.com/tj/commander.js/compare/v2.12.2...v2.14.1) | * |   |
| [cross-env](https://github.com/kentcdodds/cross-env#readme) | [5.1.1...5.1.3](https://github.com/kentcdodds/cross-env/compare/v5.1.1...v5.1.3) | [5.1.3](https://github.com/kentcdodds/cross-env/compare/v5.1.1...v5.1.3) |   | * |
| [cross-spawn](https://github.com/IndigoUnited/node-cross-spawn#readme) | [5.1.0](https://github.com/IndigoUnited/node-cross-spawn/tree/5.1.0) | [6.0.5](https://github.com/IndigoUnited/node-cross-spawn/compare/5.1.0...v6.0.5) | * |   |
| [eslint](https://eslint.org) | [4.12.1...4.18.2](https://github.com/eslint/eslint/compare/v4.12.1...v4.18.2) | [4.18.2](https://github.com/eslint/eslint/compare/v4.12.1...v4.18.2) |   | * |
| [git-url-parse](https://github.com/IonicaBizau/git-url-parse) | [7.0.1...7.2.0](https://github.com/IonicaBizau/git-url-parse/compare/7.0.1...7.2.0) | [8.1.0](https://github.com/IonicaBizau/git-url-parse/compare/7.0.1...8.1.0) | * |   |
| [github](https://github.com/mikedeboer/node-github) | [11.0.0](https://github.com/mikedeboer/node-github/tree/v11.0.0) | [13.1.0](https://github.com/mikedeboer/node-github/compare/v11.0.0...v13.1.0) | * |   |
| [lodash](https://lodash.com/) | [4.17.4...4.17.5](https://github.com/lodash/lodash/compare/4.17.4...4.17.5) | [4.17.5](https://github.com/lodash/lodash/compare/4.17.4...4.17.5) | * |   |
| [moment](http://momentjs.com) | [2.19.3...2.21.0](https://github.com/moment/moment/compare/2.19.3...2.21.0) | [2.21.0](https://github.com/moment/moment/compare/2.19.3...2.21.0) | * |   |
| [sha.js](https://github.com/crypto-browserify/sha.js) | [2.4.9...2.4.10](https://github.com/crypto-browserify/sha.js/compare/v2.4.9...v2.4.10) | [2.4.10](https://github.com/crypto-browserify/sha.js/compare/v2.4.9...v2.4.10) | * |   |