### PR TITLE
Fix up-to-date message

### DIFF
--- a/src/upgrade-request.js
+++ b/src/upgrade-request.js
@@ -22,7 +22,7 @@ function findOutdatedDeps(LOG, out) {
         }
     }
     LOG("Did not find outdated dependencies.");
-    return Promise.reject("dependencies are not up to date.");
+    return Promise.reject("dependencies are up to date.");
 }
 
 function collectModuleVersions(options) {

--- a/test/upgrade-request.test.js
+++ b/test/upgrade-request.test.js
@@ -15,7 +15,7 @@ test("findOutdatedDeps#noOutdated", t => {
     t.plan(1);
     let p = findOutdatedDeps(LOG, "");
     return p.catch(err => {
-        t.is(err, "dependencies are not up to date.");
+        t.is(err, "dependencies are up to date.");
     });
 });
 


### PR DESCRIPTION
When there are no outdated dependencies, it says: `dependencies are not up to date.`, but should it be `dependencies are up to date` (without `not`) or simply `no outdated dependencies` ?


