### PR TITLE
update dependencies at 20180321020119

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -950,8 +950,8 @@ camelcase@^4.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-lite@^1.0.30000792:
-  version "1.0.30000814"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000814.tgz#73eb6925ac2e54d495218f1ea0007da3940e488b"
+  version "1.0.30000817"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000817.tgz#e993c380eb4bfe76a2aed4223f841c02d6e0d832"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1097,8 +1097,8 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
     delayed-stream "~1.0.0"
 
 commander@^2.11.0, commander@^2.9.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 common-path-prefix@^1.0.0:
   version "1.0.0"
@@ -1323,8 +1323,8 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
 
 electron-to-chromium@^1.3.30:
-  version "1.3.37"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.37.tgz#4a92734e0044c8cf0b1553be57eae21a4c6e5fab"
+  version "1.3.40"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.40.tgz#1fbd6d97befd72b8a6f921dc38d22413d2f6fddf"
 
 empower-core@^0.6.1:
   version "0.6.2"
@@ -1363,8 +1363,8 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
 eslint@^4.8.0:
-  version "4.18.2"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.18.2.tgz#0f81267ad1012e7d2051e186a9004cc2267b8d45"
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.0.tgz#9e900efb5506812ac374557034ef6f5c3642fc4c"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -1375,7 +1375,7 @@ eslint@^4.8.0:
     doctrine "^2.1.0"
     eslint-scope "^3.7.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^3.5.2"
+    espree "^3.5.4"
     esquery "^1.0.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
@@ -1397,6 +1397,7 @@ eslint@^4.8.0:
     path-is-inside "^1.0.2"
     pluralize "^7.0.0"
     progress "^2.0.0"
+    regexpp "^1.0.1"
     require-uncached "^1.0.3"
     semver "^5.3.0"
     strip-ansi "^4.0.0"
@@ -1413,7 +1414,7 @@ espower-location-detector@^1.0.0:
     source-map "^0.5.0"
     xtend "^4.0.0"
 
-espree@^3.5.2:
+espree@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
@@ -2101,8 +2102,8 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
 is-url@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.2.tgz#498905a593bf47cc2d9e7f738372bbf7696c7f26"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.3.tgz#42f6487f61795154b098246954412048f7ab120b"
 
 is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
@@ -2463,8 +2464,8 @@ mz@^2.6.0:
     thenify-all "^1.0.0"
 
 nan@^2.3.0:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2959,6 +2960,10 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
 
+regexpp@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.0.1.tgz#d857c3a741dce075c2848dcb019a0a975b190d43"
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -3118,8 +3123,8 @@ set-immediate-shim@^1.0.1:
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
 sha.js@^2.4.5:
-  version "2.4.10"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.10.tgz#b1fde5cd7d11a5626638a07c604ab909cfa31f9b"
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"


### PR DESCRIPTION
## Updating Dependencies

| Name | Updating | Latest | dependencies | devDependencies |
|:---- |:--------:|:------:|:-:|:-:|
| [@octokit/rest](https://github.com/octokit/rest.js#readme) | [14.0.9](https://github.com/octokit/rest.js/tree/v14.0.9) | [15.2.5](https://github.com/octokit/rest.js/compare/v14.0.9...v15.2.5) | * |   |
| [ava](https://ava.li) | [0.22.0](https://github.com/avajs/ava/tree/v0.22.0) | [0.25.0](https://github.com/avajs/ava/compare/v0.22.0...v0.25.0) |   | * |
| [chokidar](https://github.com/paulmillr/chokidar) | [1.7.0](https://github.com/paulmillr/chokidar/tree/1.7.0) | [2.0.2](https://github.com/paulmillr/chokidar/compare/1.7.0...2.0.2) |   | * |
| [commander](https://github.com/tj/commander.js#readme) | [2.15.0...2.15.1](https://github.com/tj/commander.js/compare/v2.15.0...v2.15.1) | [2.15.1](https://github.com/tj/commander.js/compare/v2.15.0...v2.15.1) | * |   |
| [cross-spawn](https://github.com/IndigoUnited/node-cross-spawn#readme) | [5.1.0](https://github.com/IndigoUnited/node-cross-spawn/tree/5.1.0) | [6.0.5](https://github.com/IndigoUnited/node-cross-spawn/compare/5.1.0...v6.0.5) | * |   |
| [eslint](https://eslint.org) | [4.18.2...4.19.0](https://github.com/eslint/eslint/compare/v4.18.2...v4.19.0) | [4.19.0](https://github.com/eslint/eslint/compare/v4.18.2...v4.19.0) |   | * |
| [git-url-parse](https://github.com/IonicaBizau/git-url-parse) | [7.2.0](https://github.com/IonicaBizau/git-url-parse/tree/7.2.0) | [8.2.0](https://github.com/IonicaBizau/git-url-parse/compare/7.2.0...8.2.0) | * |   |
| [sha.js](https://github.com/crypto-browserify/sha.js) | [2.4.10...2.4.11](https://github.com/crypto-browserify/sha.js/compare/v2.4.10...v2.4.11) | [2.4.11](https://github.com/crypto-browserify/sha.js/compare/v2.4.10...v2.4.11) | * |   |

Powered by [ci-yarn-upgrade](https://github.com/taichi/ci-yarn-upgrade)