### PR TITLE
Avoid not displaying npm name in GitHub

### DIFF
--- a/src/compare.js
+++ b/src/compare.js
@@ -15,7 +15,7 @@ class Column {
 function makeColumns(entries) {
     let columns = [];
     columns.push(new Column("Name", ":---- ", cw => {
-        return cw.homepage ? `[${cw.name}](${cw.homepage})` : cw.name;
+        return cw.homepage ? `[${cw.name}](${cw.homepage})` : `\`${cw.name}\``;
     }, "left", cw => cw.name));
     columns.push(new Column("Updating", ":--------:", cw => {
         let u = cw.diffWantedURL();

--- a/test/compare.test.js
+++ b/test/compare.test.js
@@ -20,9 +20,9 @@ test("toMarkdown#simple", t => {
 
 | Name | Updating | Latest | dependencies | devDependencies | optionalDependencies |
 |:---- |:--------:|:------:|:-:|:-:|:-:|
-| classnames | 2.2.0 | 2.2.5 | * |   |   |
-| react | 15.0.0...15.3.2 | 15.3.2 |   | * |   |
-| fsevents | 1.0.0...1.0.7 | 1.0.14 |   |   | * |
+| \`classnames\` | 2.2.0 | 2.2.5 | * |   |   |
+| \`react\` | 15.0.0...15.3.2 | 15.3.2 |   | * |   |
+| \`fsevents\` | 1.0.0...1.0.7 | 1.0.14 |   |   | * |
 
 Powered by [${pkg.name}](${pkg.homepage})`.split(/[\r]?\n/);
     let actual = toMarkdown(map).split(/[\r]?\n/);


### PR DESCRIPTION
## Why

If there is no user/organization of GitHub specified by the namespace of npm, GitHub Flavored Markdown will not display the string.

e.g.

(Please see raw markdown below)

| Name | Updating | Latest | dependencies | devDependencies |
|:---- |:--------:|:------:|:-:|:-:|
| @types/node | 8.10.8...8.10.9 | 9.6.6 |   | * |

## How

If there is no repository link of npm, surround it in backquotes (``).

e.g.

| Name | Updating | Latest | dependencies | devDependencies |
|:---- |:--------:|:------:|:-:|:-:|
| `@types/node` | 8.10.8...8.10.9 | 9.6.6 |   | * |

### Other workarounds

Make it an empty link of markdown.

| Name | Updating | Latest | dependencies | devDependencies |
|:---- |:--------:|:------:|:-:|:-:|
| [@types/node]() | 8.10.8...8.10.9 | 9.6.6 |   | * |