### PR TITLE
The host and  pathPrefix options have already deprecated.

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -135,8 +135,7 @@ export default class {
         };
         if (this.url.resource !== "github.com") {
             // for GHE
-            ghopt.host = this.url.resource;
-            ghopt.pathPrefix = "/api/v3";
+            ghopt.baseUrl = `https://${this.url.resource}/api/v3`;
         }
         this.original = new GitHub(ghopt);
         this.original.authenticate({


### PR DESCRIPTION
@taichi 
The host and  pathPrefix options in @oktokit/rest.js have already deprecated so now this lib does't work for GHE. 

https://github.com/octokit/rest.js/blob/master/lib/parse-client-options.js#L29
https://github.com/octokit/rest.js/blob/master/lib/parse-client-options.js#L37

Instead of these options, use baseUrl option for it.