### PR TITLE
Wait for other git process before adding to stage

### DIFF
--- a/src/upgrade-request.js
+++ b/src/upgrade-request.js
@@ -82,12 +82,16 @@ function findExistingBranch(LOG, options, names, diff, hex) {
 }
 
 function addTargetFiles(LOG, options, git) {
+    let targets = [];
     if (options.latest) {
         LOG("Added package.json into request files because --latest is specified.");
-        git.add("package.json");
+        targets.push("package.json");
     }
-
-    return git.add("yarn.lock");
+    targets.push("yarn.lock");
+    return targets.reduce(
+        (promise, target) => promise.then(() => git.add(target)),
+        Promise.resolve()
+    );
 }
 
 function selectPushPromise(LOG, options, git, remote, branch) {


### PR DESCRIPTION
```
#!/bin/sh -eo pipefail
ci-yarn-upgrade \
    --execute \
    --verbose \
    --latest \
    --workingdir front_end
> BEGIN yarnpkg install
> END   yarnpkg install
> BEGIN yarnpkg outdated
> END   yarnpkg outdated
> Find some outdated dependencies.
> ............................................................
> Found outdated dependencies.
> BEGIN git fetch --prune origin
> END   git fetch --prune origin
> BEGIN git branch -a
> END   git branch -a
> Find existing branch.
> BEGIN git checkout -b yarn-upgrade/20181004033350/31324845ad84c9254e019972bb96909ddd917583
> END   git checkout -b yarn-upgrade/20181004033350/31324845ad84c9254e019972bb96909ddd917583
> BEGIN yarnpkg upgrade --json --latest
> END   yarnpkg upgrade --json --latest
> compute shadow dependencies
> BEGIN git config user.name XXX
> END   git config user.name XXX
> BEGIN git config user.email YYY
> END   git config user.email YYY
> Added package.json into request files because --latest is specified.
> BEGIN git add package.json
> BEGIN git add yarn.lock
{ error: '',
  errorcode: 128,
  stdout: '',
  stderr:
   'fatal: Unable to create \'/root/workspace/.git/index.lock\': File exists.\n\nAnother git process seems to be running in this repository, e.g.\nan editor opened by \'git commit\'. Please make sure all processes\nare terminated then try again. If it still fails, a git process\nmay have crashed in this repository earlier:\nremove the file manually to continue.\n' }
Exited with code 1
```

`git add file` が連続した時に process が複数走ることによって怒られたので待ち合わせ