### PR TITLE
Update git-url-parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "colors": "^1.3.1",
     "commander": "^2.19.0",
     "cross-spawn": "^6.0.5",
-    "git-url-parse": "^10.1.0",
+    "git-url-parse": "^11.0.1",
     "lodash": "^4.17.11",
     "moment": "^2.15.0",
     "mz": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2060,20 +2060,20 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-git-up@^2.0.0:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/git-up/-/git-up-2.0.10.tgz#20fe6bafbef4384cae253dc4f463c49a0c3bd2ec"
-  integrity sha512-2v4UN3qV2RGypD9QpmUjpk+4+RlYpW8GFuiZqQnKmvei08HsFPd0RfbDvEhnE4wBvnYs8ORVtYpOFuuCEmBVBw==
+git-up@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.0.tgz#6c17040afa488fafc118400d5e0f12c079974aba"
+  integrity sha512-zoRfnGaUmRfp2tbVF5tynNFLalKDk3CwlTepXt6ZtFDaWP7xY/pzHjI2YrLiaz503tEnzZWURN4QmcfUtEd0YA==
   dependencies:
     is-ssh "^1.3.0"
-    parse-url "^1.3.0"
+    parse-url "^5.0.0"
 
-git-url-parse@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-10.1.0.tgz#a27813218f8777e91d15f1c121b83bf14721b67e"
-  integrity sha512-goZOORAtFjU1iG+4zZgWq+N7It09PqS3Xsy43ZwhP5unDD0tTSmXTpqULHodMdJXGejm3COwXIhIRT6Z8DYVZQ==
+git-url-parse@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.0.1.tgz#3fc0b462d1b29ce2cbe19768673938d4845eda0b"
+  integrity sha512-+Ebfi/DWdVyj8gxrSqYlXS2G/Mdywm7LLV5MNC8sa6EAhXOMNzgTKlOq2mxBiGuHAx47rYvpzTjvS0XFuIvDWA==
   dependencies:
-    git-up "^2.0.0"
+    git-up "^4.0.0"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -3212,6 +3212,11 @@ normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize-url@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
+  integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
@@ -3443,12 +3448,22 @@ parse-ms@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
   integrity sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=
 
-parse-url@^1.3.0:
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-1.3.11.tgz#57c15428ab8a892b1f43869645c711d0e144b554"
-  integrity sha1-V8FUKKuKiSsfQ4aWRccR0OFEtVQ=
+parse-path@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-4.0.0.tgz#38e50496a3e38bc1a0ced205a12a7fa91e719332"
+  integrity sha512-F2VzhusH0Z2Dgp8SMrFMkYz2sI40deaax2AEmK1UYOf2NY77b0yJzqZ6iUjXwUHJ4VVvJNuV3S+oVEwcPjsxSQ==
   dependencies:
     is-ssh "^1.3.0"
+    protocols "^1.4.0"
+
+parse-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.0.tgz#01538e9f2df5c612b8b5e1124f1a108787495d08"
+  integrity sha512-ePfnXkes247DaA0IBTU1YE6/SxM09/Y+QJm/Ne4E9VYY4H+g5/qJ+TG0p5flEqh3qnb+XXbZuob2kqrqIBJpPA==
+  dependencies:
+    is-ssh "^1.3.0"
+    normalize-url "^3.3.0"
+    parse-path "^4.0.0"
     protocols "^1.4.0"
 
 pascalcase@^0.1.1:


### PR DESCRIPTION
git-url-parseを11.0.1にアップデートするとリポジトリのURLが正しく生成されるようになりました。

Fix #91
