### PR TITLE
Use .gitdata.listRefs instead of .gitdata.getTags

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -72,9 +72,9 @@ function selectGetTagsPromise(LOG, github, c) {
         let url = giturl(c.repo);
         if (url.owner && url.name) {
             LOG(`BEGIN getTags from ${url.toString("https")}`);
-            let request = { owner: url.owner, repo: url.name };
+            let request = { owner: url.owner, repo: url.name, namespace: "tags/" };
             return Promise.all([
-                github.gitdata.getTags(request)
+                github.gitdata.listRefs(request)
                     .then(res => handler([], res))
             ]).then(([tags]) => {
                 LOG(`END   getTags ${tags}`);


### PR DESCRIPTION
## WHAT
- when getTags, use .`gitdata.listRefs` instead of `.gitdata.getTags`

## WHY
I use v0.7.3, but error occured.

```
TypeError: github.gitdata.getTags is not a function
    at selectGetTagsPromise (/usr/local/share/.config/yarn/global/node_modules/ci-yarn-upgrade/lib/github.js:107:48)
    at reconcile (/usr/local/share/.config/yarn/global/node_modules/ci-yarn-upgrade/lib/github.js:132:44)
    at data.children.map.e (/usr/local/share/.config/yarn/global/node_modules/ci-yarn-upgrade/lib/github.js:146:41)
    at Array.map (<anonymous>)
    at then.data (/usr/local/share/.config/yarn/global/node_modules/ci-yarn-upgrade/lib/github.js:146:32)
    at process._tickCallback (internal/process/next_tick.js:68:7)
Exited with code 1
```

The cause is @octokit/rest version.
ci-yarn-update current use [@octokit/rest@16.9.0](https://github.com/taichi/ci-yarn-upgrade/blob/master/yarn.lock#L362).
But `.gitdata.getTags` remove since v16.0.1
ref. https://github.com/octokit/rest.js/releases/tag/v16.0.1

I use `.gitdata.listRefs` instead.
https://octokit.github.io/rest.js/#api-Git-listRefs
